### PR TITLE
Role names

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": false,
   "devDependencies": {
     "@types/node": "^13.11.0",
+    "@types/string-similarity": "^3.0.0",
     "@types/ws": "^7.2.3",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
@@ -22,7 +23,8 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "discord.js": "^12.1.1"
+    "discord.js": "^12.1.1",
+    "string-similarity": "^4.0.1"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/src/cmds/setcolor.ts
+++ b/src/cmds/setcolor.ts
@@ -1,14 +1,34 @@
 import { Command } from './Command';
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, Message, Role } from 'discord.js';
+import { findBestMatch } from 'string-similarity';
 
 function validateHexColor(color: string): boolean {
   const regex = /[0-9A-Fa-f]{6}/gm;
   return regex.test(color);
 }
 
+async function findRole(msg: Message, role: string) {
+  const guildRole =
+    msg.guild?.roles.cache.get(role) ||
+    msg.guild?.roles.cache.find(
+      r => r.name.toLowerCase() === role.toLowerCase()
+    );
+  if (guildRole) return guildRole;
+  // Match the nearest role name
+  const guildRoles: Role[] | undefined = msg.guild?.roles.cache.array();
+  if (!guildRoles) return null;
+  const roleArray: string[] = guildRoles.map(r => r.name.toLowerCase());
+  const {
+    bestMatchIndex,
+    bestMatch: { rating },
+  } = findBestMatch(role.toLowerCase(), roleArray);
+  if (rating < 0.3) return null;
+  return guildRoles[bestMatchIndex];
+}
+
 export const cmd = new Command(
   'setcolor',
-  async (MRC, msg, [rID, hexColor, ...reason]) => {
+  async (MRC, msg, [hexColor, ...rID]) => {
     if (!msg.member?.permissions.has('MANAGE_ROLES')) {
       // Do Nothing
     } else if (!rID) {
@@ -18,9 +38,12 @@ export const cmd = new Command(
     } else if (!validateHexColor(hexColor)) {
       msg.channel.send('Invalid parameter: `hex code`');
     } else {
-      const role = await msg.guild?.roles.fetch(rID);
+      const role = await findRole(msg, rID.join(' '));
       if (role) {
-        role.setColor(hexColor, reason.join(' '));
+        role.setColor(
+          hexColor,
+          `Role color changed on behalf of ${msg.author.tag} at ${new Date()}`
+        );
         msg.channel.send(
           `Role \`${role.name} (${role.id})\` is now set to color \`${hexColor}\``
         );
@@ -36,7 +59,7 @@ export const cmd = new Command(
   },
   {
     description: "Change a role's color to a specified hex code",
-    usage: ['setcolor {rold id} {hex code} [reason]'],
+    usage: ['setcolor {hex code} {role name | id | mention}'],
     aliases: ['sc', 'setcol'],
   }
 );

--- a/src/cmds/setcolor.ts
+++ b/src/cmds/setcolor.ts
@@ -10,6 +10,7 @@ function validateHexColor(color: string): boolean {
 async function findRole(msg: Message, role: string) {
   const guildRole =
     msg.guild?.roles.cache.get(role) ||
+    msg.mentions.roles.first() ||
     msg.guild?.roles.cache.find(
       r => r.name.toLowerCase() === role.toLowerCase()
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.0.tgz#390ea202539c61c8fa6ba4428b57e05bc36dc47b"
   integrity sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==
 
+"@types/string-similarity@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/string-similarity/-/string-similarity-3.0.0.tgz#12b655f1aab0156049657a4e9287caf3e6718d93"
+  integrity sha512-vhHkPKxl0cudrbxr5Dog1HVgUGXtmyYP95qy1da/h5gFEzIqDMN/+SjJAS7/6DEAdeI+AJQX8zrdWXL3wP4FRA==
+
 "@types/ws@^7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.3.tgz#a3add56077ac6cc9396b9502c7252a1635922032"
@@ -985,6 +990,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+string-similarity@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.1.tgz#ea7c11f0093cb3088cdcc5eb16cfd90cb54962f7"
+  integrity sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==
 
 string-width@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Note: I had to remove the 'reason' parameter to for it to work.

This allows role names and mentions to be used as valid input, as well as ids.

The setcolor command can be used like this:

`{prefix}setcolor ffffff 1234568790...`
`{prefix}setcolor ffffff @role`
`{prefix}setcolor ffffff role names with spaces work too!`
`{prefix}setcolor ffffff role names with spaces` - The bot will find the nearest matching role name if it cannot find the role by ID, mention or exact matching role name

![2020-04-08-11:35:02](https://user-images.githubusercontent.com/36977340/78803600-341eba00-798d-11ea-878a-f5e36a5d0f08.png)
